### PR TITLE
fix(agent): ensure deleted images are not managed

### DIFF
--- a/fixtures/agent_test/images_deleted.yaml
+++ b/fixtures/agent_test/images_deleted.yaml
@@ -1,0 +1,14 @@
+apiVersion: stvz.io/v1
+kind: Image
+metadata:
+  name: base
+  namespace: default
+  deletionTimestamp: "2024-04-01T00:00:00Z"
+spec:
+  enabled: true
+  pollInterval: 30s 
+  images:
+    - name: docker.io/library/debian
+      tags:
+        - bookworm-slim
+        - bullseye-slim

--- a/pkg/agent/images.go
+++ b/pkg/agent/images.go
@@ -30,6 +30,11 @@ func ListImages(ctx context.Context, c client.Client, ns string, nodeLabels map[
 	}
 
 	for _, image := range imageList.Items {
+		// Skip deleted images.
+		if image.GetDeletionTimestamp() != nil {
+			continue
+		}
+
 		matched, err := matched(image.Spec.Selector, nodeLabels)
 		if err != nil {
 			return nil, err

--- a/pkg/agent/images_test.go
+++ b/pkg/agent/images_test.go
@@ -16,7 +16,17 @@ import (
 
 var _ = Describe("Images", func() {
 
-	Context("Get", func() {
+	Context("ListImages", func() {
+		It("should not return images with deletion timestamps", func() {
+			By("mocking a new client")
+			file := path.Join(fixtures, "images_deleted.yaml")
+			c := mock.NewClient().WithLogger(logger).WithFixtureOrDie(file)
+
+			By("getting the images")
+			images, err := ListImages(ctx, c, "", map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(images).To(HaveLen(0))
+		})
 		It("should return the images across all namespaces matching all nodes", func() {
 			By("mocking a new client")
 			file := path.Join(fixtures, "images.yaml")


### PR DESCRIPTION
Fixes an issue where an image pending deletion was still showing up as managed.  This had been adressed before the refactor and was not brought over.