### PR TITLE
fix(monitor): fix monitor shutdown

### DIFF
--- a/examples/base.yaml
+++ b/examples/base.yaml
@@ -6,20 +6,7 @@ spec:
   enabled: true
   pollInterval: 30s
   images:
-    - name: docker.io/library/alpine
-      tags:
-        - "3.19"
-        - "3.18"
-    - name: docker.io/library/busybox
-      tags:
-        - "1.36"
-        - "1.35"
     - name: docker.io/library/debian
       tags:
         - bookworm-slim
         - bullseye-slim
-        - buster-slim
-    - name: docker.io/library/ubuntu
-      tags:
-        - jammy
-        - noble

--- a/pkg/controller/image/controller.go
+++ b/pkg/controller/image/controller.go
@@ -68,16 +68,12 @@ func (c Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 		}, err
 	}
 
-	logger.V(8).Info("observed image", "obj", observed.image)
-
-	// TODO: I think there'a an issue here.  I'm using this to catch any potential races
-	// where the image has been deleted and can't be found, but I'm not sure this is the
-	// only case where a nil value could happen without an error.  I think that's the case
-	// but not quite sure.
+	// The image has been deleted.
 	if observed.image == nil {
-		logger.V(8).Info("image not found, exiting reconcile loop")
 		return ctrl.Result{}, nil
 	}
+
+	logger.V(8).Info("observed image", "obj", observed.image)
 
 	// TODO: Because we don't do anything with the image we could just return without
 	// a requeue here.  Check this out later.


### PR DESCRIPTION
Fixes the issues with the monitor shutdown, cleans it up a bit, and reorders some logs and checks in the controller.  I just ran into an issue where I hit docker's rate limit.  I'll want to make sure that I address that situation a little better (and handle the situation). Seems like this would be a good scenario for the local registry.