### PR TITLE
feat(metrics): initial metrics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,25 +1,27 @@
 # Notes
 
 ## CURRENT
-* Create a new type called RegistryMirror.  I think that we actually create a more wholistic process here where we have a producer that pushes into a queue then a set of consumers that mirror images.  There will be a new injection rule that will transform images to use the local repository only.  That way they can keep the pull, but still restrict external pulling (and it's quicker).  Initially it requires a local registry to be available.  This may be pushed off depending on time.
+
+* Work on the monitor features.  Move to a worker model instead of per image. Fix the selectors - going back to the per image/tag updates so we can get the correct metrics and status.
+* Figure out a way to block until a pull is available or a delete has successfully processed so we don't try multiple times.
+* Set up dependabot, branch protection, and actions.
 * Additional work on the readme and docs.
 * Dockerfiles.
 * Package manifests.
 
 ## MVP
+* Create a new type called RegistryMirror.  I think that we actually create a more wholistic process here where we have a producer that pushes into a queue then a set of consumers that mirror images.  There will be a new injection rule that will transform images to use the local repository only.  That way they can keep the pull, but still restrict external pulling (and it's quicker).  Initially it requires a local registry to be available.  This may be pushed off depending on time.
 * Fix all known bugs.
 * Clean up the processImage method (if time, add some testing around).
-* Remove envtest from the controller in favor of the client mock.
 * Move TODO items into github issues.
 * Set up github actions.
 * Finish and polish the README and other docs.
 
-## BUG
-* After a image deletion and re-apply, the monitor didn't start back up again (I think this is due to not shutting it down in the finalizer).
-* Monitor not shutting down.
-* Finalizer doesn't appear to be requeuing itself, or if it is it's not running the finalizer again to remove.
+## BUGS
+* Fix monitor selectors
 
 ## LATER
+* Better monitor with dedicated workers instead of a single process per image.
 * Standardize tests.  The layout has varied as I've gotten used to the new framework.
 * Provide a way for coral to override annotations and force pullpolicies and selectors.  By default, have them disabled so the pre-fetch is more of a convienience feature and if the container doesn't exist on the system it pulls it so no selectors are needed.  However, there may be the case where admins will want to lock image use to those that are already available (or maybe open everything up to only-mirrored) and want to override individual settings.
 * See if we can speed up image loads through local registries or shared image mounts. AWS uses a snapshotted volume that it mounts into the node so all the images are available on startup.  But I think we can still speed it up if we are hosting a local registry (may need to have an HPA attached to it to guard against scale)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
+	github.com/prometheus/client_golang v1.19.0
 	github.com/spf13/cobra v1.8.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.62.1
@@ -51,10 +52,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
-	github.com/prometheus/common v0.50.0 // indirect
+	github.com/prometheus/common v0.51.1 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,12 +87,12 @@ github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7km
 github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
 github.com/prometheus/client_model v0.6.0 h1:k1v3CzpSRUTrKMppY35TLwPvxHqBu0bYgxZzqGIgaos=
 github.com/prometheus/client_model v0.6.0/go.mod h1:NTQHnmxFpouOD0DpvP4XujX3CdOAGQPoaGhyTchlyt8=
-github.com/prometheus/common v0.50.0 h1:YSZE6aa9+luNa2da6/Tik0q0A5AbR+U003TItK57CPQ=
-github.com/prometheus/common v0.50.0/go.mod h1:wHFBCEVWVmHMUpg7pYcOm2QUR/ocQdYSJVQJKnHc3xQ=
+github.com/prometheus/common v0.51.1 h1:eIjN50Bwglz6a/c3hAgSMcofL3nD+nFQkV6Dd4DsQCw=
+github.com/prometheus/common v0.51.1/go.mod h1:lrWtQx+iDfn2mbH5GUzlH9TSHyfZpHkSiG1W7y3sF2Q=
 github.com/prometheus/procfs v0.13.0 h1:GqzLlQyfsPbaEHaQkO7tbDlriv/4o5Hudv6OXHGKX7o=
 github.com/prometheus/procfs v0.13.0/go.mod h1:cd4PFCR54QLnGKPaKGA6l+cfuNXtht43ZKY6tow0Y1g=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	agentError = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coral_agent_error",
+			Help: "Errors that occurred while the agent is running.",
+		},
+		[]string{"error"},
+	)
+
+	agentImageError = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coral_agent_image_error",
+			Help: "Errors that occurred while the agent is running image processing.",
+		},
+		[]string{"image", "error"},
+	)
+
+	agentRunDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "coral_agent_run_duration_ms",
+			Help:    "The duration of the agent run.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{},
+	)
+
+	agentImagePulls = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "coral_agent_image_pulls",
+			Help: "The number of image pulls.",
+		},
+	)
+
+	agentImageRemovals = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "coral_agent_image_removals",
+			Help: "The number of image removals.",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(agentError)
+	metrics.Registry.MustRegister(agentImageError)
+	metrics.Registry.MustRegister(agentRunDuration)
+	metrics.Registry.MustRegister(agentImagePulls)
+	metrics.Registry.MustRegister(agentImageRemovals)
+}

--- a/pkg/controller/image/metrics.go
+++ b/pkg/controller/image/metrics.go
@@ -1,0 +1,20 @@
+package image
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	observerError = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coral_image_controller_observer_error",
+			Help: "The number of errors that occurred while observing the state of an image.",
+		},
+		[]string{"name", "namespace"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(observerError)
+}

--- a/pkg/monitor/metrics.go
+++ b/pkg/monitor/metrics.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	monitorError = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coral_monitor_error",
+			Help: "The number of errors that occurred while monitoring an image.",
+		},
+		[]string{"name", "namespace", "error"},
+	)
+
+	monitorDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "coral_monitor_duration_seconds",
+			Help:    "The duration of monitoring run for an image.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"name", "namespace"},
+	)
+
+	monitorImagesPending = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "coral_monitor_images_pending",
+			Help: "The number of nodes that have the image pending",
+		},
+		[]string{"name", "namespace", "image"},
+	)
+
+	monitorImagesAvailable = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "coral_monitor_images_available",
+			Help: "The number of nodes that have the image available",
+		},
+		[]string{"name", "namespace", "image"},
+	)
+
+	monitorImagesDeleting = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "coral_monitor_images_deleting",
+			Help: "The number of nodes that have the image deleting",
+		},
+		[]string{"name", "namespace", "image"},
+	)
+
+	monitorTotalNodesSelected = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "coral_monitor_total_nodes_selected",
+			Help: "The number of nodes that were selected for monitoring",
+		},
+		[]string{"name", "namespace", "image"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(monitorError)
+	metrics.Registry.MustRegister(monitorDuration)
+	metrics.Registry.MustRegister(monitorImagesPending)
+	metrics.Registry.MustRegister(monitorImagesAvailable)
+	metrics.Registry.MustRegister(monitorImagesDeleting)
+	metrics.Registry.MustRegister(monitorTotalNodesSelected)
+}


### PR DESCRIPTION
First pass at some initial custom metrics for monitoring the state of the controller and agent.  The monitor has not been fully instrumented as there are some structural changes that will be following.  In addition, because the agent does not block for pulls/removals the actual count for the metrics is wrong.  Updates for some sort of blocking mechanism are on the way.